### PR TITLE
Break legacy `fabric` dependency

### DIFF
--- a/src/main/java/one/devos/nautical/canary/Canary.java
+++ b/src/main/java/one/devos/nautical/canary/Canary.java
@@ -2,6 +2,7 @@ package one.devos.nautical.canary;
 
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.resources.ResourceLocation;
+import one.devos.nautical.canary.feature.FabricApiCheck;
 
 public class Canary implements ModInitializer {
 	public static final String ID = "canary";
@@ -9,6 +10,7 @@ public class Canary implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		CanaryPackets.register();
+		FabricApiCheck.checkForDeprecatedApi();
 	}
 
 	public static ResourceLocation id(String path) {

--- a/src/main/java/one/devos/nautical/canary/Config.java
+++ b/src/main/java/one/devos/nautical/canary/Config.java
@@ -27,7 +27,7 @@ public record Config(boolean printBlockStateReport, int diagnosticsPermissionLev
 			Codec.INT.optionalFieldOf("desync_diagnostics_permission_level", 4).forGetter(Config::diagnosticsPermissionLevel),
 			Codec.STRING.listOf().optionalFieldOf("tracked_data_whitelist", List.of()).forGetter(Config::trackedDataWhitelist),
 			Codec.STRING.listOf().optionalFieldOf("state_builder_whitelist", List.of()).forGetter(Config::stateBuilderWhitelist),
-			Codec.BOOL.optionalFieldOf("break-legacy-fabric-dependency", true).forGetter(Config::breakLegacyFabricDependency)
+			Codec.BOOL.optionalFieldOf("break_legacy_fabric_dependency", true).forGetter(Config::breakLegacyFabricDependency)
 			).apply(instance, Config::new));
 
 	public static final Config INSTANCE = load();

--- a/src/main/java/one/devos/nautical/canary/Config.java
+++ b/src/main/java/one/devos/nautical/canary/Config.java
@@ -17,7 +17,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.fabricmc.loader.api.FabricLoader;
 
 public record Config(boolean printBlockStateReport, int diagnosticsPermissionLevel,
-					 List<String> trackedDataWhitelist, List<String> stateBuilderWhitelist) {
+					 List<String> trackedDataWhitelist, List<String> stateBuilderWhitelist, boolean breakLegacyFabricDependency) {
 
 	public static final Path PATH = FabricLoader.getInstance().getConfigDir().resolve("canary.json");
 	private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -26,8 +26,9 @@ public record Config(boolean printBlockStateReport, int diagnosticsPermissionLev
 			Codec.BOOL.optionalFieldOf("print_blockstate_report", false).forGetter(Config::printBlockStateReport),
 			Codec.INT.optionalFieldOf("desync_diagnostics_permission_level", 4).forGetter(Config::diagnosticsPermissionLevel),
 			Codec.STRING.listOf().optionalFieldOf("tracked_data_whitelist", List.of()).forGetter(Config::trackedDataWhitelist),
-			Codec.STRING.listOf().optionalFieldOf("state_builder_whitelist", List.of()).forGetter(Config::stateBuilderWhitelist)
-	).apply(instance, Config::new));
+			Codec.STRING.listOf().optionalFieldOf("state_builder_whitelist", List.of()).forGetter(Config::stateBuilderWhitelist),
+			Codec.BOOL.optionalFieldOf("break-legacy-fabric-dependency", true).forGetter(Config::breakLegacyFabricDependency)
+			).apply(instance, Config::new));
 
 	public static final Config INSTANCE = load();
 
@@ -39,7 +40,8 @@ public record Config(boolean printBlockStateReport, int diagnosticsPermissionLev
 		return new Config(
 				false, 4,
 				List.of("com.example.mymod.Utilities"),
-				List.of("net.example.examplemod.Utils")
+				List.of("net.example.examplemod.Utils"),
+				true
 		);
 	}
 

--- a/src/main/java/one/devos/nautical/canary/feature/FabricApiCheck.java
+++ b/src/main/java/one/devos/nautical/canary/feature/FabricApiCheck.java
@@ -12,7 +12,7 @@ public class FabricApiCheck {
 			for (ModContainer modContainer : FabricLoader.getInstance().getAllMods()) {
 				for (ModDependency dependency : modContainer.getMetadata().getDependencies()) {
 					if (dependency.getModId().equals("fabric")) {
-						throw new CanaryException("Depending on `fabric` and not `fabric-api` has been deprecated since 1.19.3.");
+						throw new CanaryException("Mod "+modContainer.getMetadata().getName()+" depends on `fabric` and not `fabric-api`. This behaviour has been deprecated since 1.19.3.");
 					}
 				}
 			}

--- a/src/main/java/one/devos/nautical/canary/feature/FabricApiCheck.java
+++ b/src/main/java/one/devos/nautical/canary/feature/FabricApiCheck.java
@@ -1,0 +1,21 @@
+package one.devos.nautical.canary.feature;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModDependency;
+import one.devos.nautical.canary.CanaryException;
+import one.devos.nautical.canary.Config;
+
+public class FabricApiCheck {
+	public static void checkForDeprecatedApi() {
+		if (Config.INSTANCE.breakLegacyFabricDependency()) {
+			for (ModContainer modContainer : FabricLoader.getInstance().getAllMods()) {
+				for (ModDependency dependency : modContainer.getMetadata().getDependencies()) {
+					if (dependency.getModId().equals("fabric")) {
+						throw new CanaryException("Depending on `fabric` and not `fabric-api` has been deprecated since 1.19.3.");
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Since [Fabric API 0.58.6 for 1.19.2/1.19.3](https://github.com/FabricMC/fabric/commit/f60060dfe365941c3b7514d1e53cc7e09dbd671e), Fabric API's modid has been `fabric-api`, not `fabric`. However, since Fabric API still provides `fabric` to this day, some mod developers still depend on `fabric`, despite this causing confusion to users when an error blames Fabric API.

This PR adds an enabled-by-default config option to break these mods, throwing the following error:
```
Mod example-mod depends on `fabric` and not `fabric-api`. This behaviour has been deprecated since 1.19.3.
```

I'd like to add testmod coverage for this, but currently adding `fabric` as a dependency on the testmod doesn't properly trigger the behaviour, despite it throwing with mods in production as intended. Tested against Fabric Shield Lib.

Feel free to make this disabled by default as well, but being able to track down these mods would be useful behaviour for Canary in my opinion.